### PR TITLE
Update recovery.fstab

### DIFF
--- a/recovery.fstab
+++ b/recovery.fstab
@@ -1,6 +1,5 @@
 /system       ext4          /dev/block/platform/mtk-msdc.0/by-name/system
 /data         ext4          /dev/block/platform/mtk-msdc.0/by-name/userdata   length=-16384
-/oem          ext4          /dev/block/platform/mtk-msdc.0/by-name/oem flags=display="OEM";backup=1;
 /cache        ext4          /dev/block/platform/mtk-msdc.0/by-name/cache
 /boot         emmc          /dev/block/platform/mtk-msdc.0/by-name/boot
 /logo         emmc          /dev/block/platform/mtk-msdc.0/by-name/logo flags=display="Logo";backup=1
@@ -8,3 +7,4 @@
 /nvram 	      emmc          /dev/block/platform/mtk-msdc.0/by-name/nvram flags=display="IMEI/NVRAM";backup=1
 /sec_ro       emmc          /dev/block/platform/mtk-msdc.0/by-name/secro flags=subpartitionof=/nvram;backup=1
 /usb_otg      auto          /dev/block/sda1 /dev/block/sda                    flags=display="USB-OTG";storage;wipeingui;removable
+


### PR DESCRIPTION
/oem          ext4          /dev/block/platform/mtk-msdc.0/by-name/oem flags=display="OEM";backup=1;
Failed to mount '/oem' (Invalid argument)
OEM not used on hennessy.